### PR TITLE
Add -l shortcut for --list

### DIFF
--- a/index.js
+++ b/index.js
@@ -147,7 +147,7 @@ async function main() {
     .version(package.version)
     .option('--init', 'Creates a .pr-train.yml file with an example configuration')
     .option('-p, --push', 'Push changes')
-    .option('--list', 'List branches in current train')
+    .option('-l, --list', 'List branches in current train')
     .option('-r, --rebase', 'Rebase branches rather than merging them')
     .option('-f, --force', 'Force push to remote')
     .option('--push-merged', 'Push all branches (inclusing those that have already been merged into master)')


### PR DESCRIPTION
Example:

```
$ git pr-train -l
I've found these partial branches:
 -> zoe_branch_fix_first_thing
 -> zoe_branch_fix_the_other_thing
 -> zoe_branch_update_tests
 -> zoe_branch_regenerate_noisy_snapshots
 -> zoe_fix_the_important_things (combined)
```