### PR TITLE
Add reading of PR title and body from branch config

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Now whenever you have a chain of branches, list them in `.pr-train.yml` to tell 
 
 **Pre-requisite**: Create a `${HOME}/.pr-train` file with a single line which is your GH personal access token (you can create one [here](https://github.com/settings/tokens)). The `repo` scope, with ` Full control of private repositories` is needed.
 
-Run `git pr-train -p --create-prs` to create GitHub PRs with a "content table" section. PR titles are taken from the commit message titles of each branch HEAD. You'll be promted before the PRs are created.
+Run `git pr-train -p --create-prs` to create GitHub PRs with a "content table" section. PR titles and descriptions are taken from `title` and `body` values of branch configs in `.yml` file detailed further down, or from commit message titles and bodies of each branch HEAD. You'll be promted before the PRs are created.
 
 If you run with `--create-prs` again, `pr-train` will only override the Table of Contents in your PR, it will _not_ change the rest of the PR descriptions.
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ trains:
   big billing refactoring:
     - fred_billing-refactor_frontend_bits
     - fred_billing-refactor_backend_bits
+        title: BE changes for billing refactor # optional PR title
+        body: This refactor... # optional PR description
     - fred_billing-refactor_tests
   #
   # ...config for older trains follows...

--- a/index.js
+++ b/index.js
@@ -118,10 +118,10 @@ async function getBranchesConfigInCurrentTrain(sg, config) {
 
 /**
  * Returns object where keys are branch names, and values are
- * branch configs (`title`, `body`, `combined` etc.) or branch names
+ * branch configs (with `title`, `body`, `combined` etc.) or branch names
  * (stubs for compatibility).
  *
- * This object is useful for quick access to branch config when looping
+ * This object is useful for quick check of branch config when looping
  * over branch names.
  *
  * @param {Array.<BranchCfg>} trainCfg

--- a/index.js
+++ b/index.js
@@ -117,7 +117,7 @@ async function getBranchesConfigInCurrentTrain(sg, config) {
 }
 
 /**
- * Returns objects where keys are branch names, and values are
+ * Returns object where keys are branch names, and values are
  * branch configs (`title`, `body`, `combined` etc.) or branch names
  * (stubs for compatibility).
  *


### PR DESCRIPTION
Examples of PR title and body, both optional:

```yml
# .pr-train.yml

trains:
  Super duper train:
    - oleg-improve-readme:
        title: Readme improvements
        body: Now readme is the best
    - oleg-other-improvements:
    - oleg-improvements-combined:
        combined: true
        title: The big one # Works for combined branch too! And body is optional.
```

If `title` is not found in branch config, it will be read from `git log` just as before, along with `body`.

Resolves #6.