### PR TITLE
Allow specifying the base branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 node_modules
+# Intellij IDE project settings
 .idea
+# Because dogfooding
+.pr-train.yml

--- a/README.md
+++ b/README.md
@@ -108,3 +108,28 @@ Unlike the sub-branches, the combined branch doesn't need to exist when you run 
 Run `git pr-train` in your working dir when you're on any branch that belongs to a PR train. You don't have to be on the first branch, any branch will do. Use `-r/--rebase` option if you'd like to rebase branches on top of each other rather than merge (note: you will have to push with `git pr-train -pf` in that case).
 
 `git pr-train -p` will merge/rebase and push your updated changes to remote `origin` (configurable via `--remote` option).
+
+## No master? No problem!
+
+_All your base are belong to us._ - CATS
+
+Are you working in a repository that doesn't use `master` as the main (default) branch? 
+For example, newer repos use `main` instead. 
+Or do you have a different branch that you want all PR trains to use as a base?
+
+Add a section to the top of the config like so:
+
+```yml
+prs:
+  main-branch-name: main
+
+trains:
+  # existing train config
+```
+
+### Override the base branch when creating PRs
+
+You can override the base branch to use when creating PRs by passing the `--base <branch-name>`. This takes precedence 
+over the main branch specified in the config file.
+
+e.g. `git pr-train -p -c -b feat/my-feature-base`

--- a/cfg_template.yml
+++ b/cfg_template.yml
@@ -1,3 +1,7 @@
+prs:
+  # Change this if you use a different name for your default branch (e.g. main)
+  main-branch-name: master
+
 trains:
   # This is an example. This PR train would have 4 branches plus 1 "combined" branch to run tests etc on.
   #

--- a/cfg_template.yml
+++ b/cfg_template.yml
@@ -1,6 +1,6 @@
 prs:
-  # Change this if you use a different name for your default branch (e.g. main)
-  main-branch-name: master
+  # Uncomment this if you use a different name for your default branch (e.g. "main" instead of "master")
+  # main-branch-name: main
 
 trains:
   # This is an example. This PR train would have 4 branches plus 1 "combined" branch to run tests etc on.

--- a/consts.js
+++ b/consts.js
@@ -1,6 +1,6 @@
 module.exports = {
     DEFAULT_REMOTE: 'origin',
-    DEFAULT_MAIN_BRANCH: 'master',
+    DEFAULT_BASE_BRANCH: 'master',
     MERGE_STEP_DELAY_MS: 1000,
     MERGE_STEP_DELAY_WAIT_FOR_LOCK: 2500,
 }

--- a/consts.js
+++ b/consts.js
@@ -1,5 +1,6 @@
 module.exports = {
     DEFAULT_REMOTE: 'origin',
+    DEFAULT_MAIN_BRANCH: 'master',
     MERGE_STEP_DELAY_MS: 1000,
     MERGE_STEP_DELAY_WAIT_FOR_LOCK: 2500,
 }

--- a/github.js
+++ b/github.js
@@ -3,7 +3,7 @@ const octo = require('octonode');
 const promptly = require('promptly');
 const {
   DEFAULT_REMOTE,
-  DEFAULT_MAIN_BRANCH
+  DEFAULT_BASE_BRANCH
 } = require('./consts');
 const fs = require('fs');
 const get = require('lodash/get');
@@ -103,7 +103,7 @@ async function ensurePrsExist({
   allBranches,
   combinedBranch,
   remote = DEFAULT_REMOTE,
-  baseBranch = DEFAULT_MAIN_BRANCH
+  baseBranch = DEFAULT_BASE_BRANCH
 }) {
   //const allBranches = combinedBranch ? sortedBranches.concat(combinedBranch) : sortedBranches;
   const octoClient = octo.client(readGHKey());

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ const fs = require('fs');
 const yaml = require('js-yaml');
 const { ensurePrsExist, readGHKey, checkGHKeyExists } = require('./github');
 const colors = require('colors');
-const { DEFAULT_REMOTE, DEFAULT_MAIN_BRANCH, MERGE_STEP_DELAY_MS, MERGE_STEP_DELAY_WAIT_FOR_LOCK } = require('./consts');
+const { DEFAULT_REMOTE, DEFAULT_BASE_BRANCH, MERGE_STEP_DELAY_MS, MERGE_STEP_DELAY_WAIT_FOR_LOCK } = require('./consts');
 const path = require('path');
 // @ts-ignore
 const package = require('./package.json');
@@ -64,7 +64,7 @@ async function pushBranches(sg, branches, forcePush, remote = DEFAULT_REMOTE) {
   console.log('All changes pushed ' + emoji.get('white_check_mark'));
 }
 
-async function getUnmergedBranches(sg, branches, baseBranch = DEFAULT_MAIN_BRANCH) {
+async function getUnmergedBranches(sg, branches, baseBranch = DEFAULT_BASE_BRANCH) {
   const mergedBranchesOutput = await sg.raw(['branch', '--merged', baseBranch]);
   const mergedBranches = mergedBranchesOutput
     .split('\n')
@@ -211,7 +211,7 @@ async function main() {
     process.exit(1);
   }
 
-  const defaultBase = getConfigOption(ymlConfig, 'prs.main-branch-name') || DEFAULT_MAIN_BRANCH;
+  const defaultBase = getConfigOption(ymlConfig, 'prs.main-branch-name') || DEFAULT_BASE_BRANCH;
 
   program
     .version(package.version)

--- a/index.js
+++ b/index.js
@@ -80,9 +80,8 @@ async function getConfigPath(sg) {
 
 /**
  * @typedef {string | Object.<string, { combined: boolean, initSha?: string }>} BranchCfg
- * @typedef {{ mainBranch?: string, 'main-branch'?: string }} PrsCfg
  * @typedef {Object.<string, Array.<string | BranchCfg>>} TrainCfg
- * @typedef {{ prs?: PrsCfg, trains: Array.<TrainCfg>}} YamlCfg
+ * @typedef {{ prs?: Object, trains: Array.<TrainCfg>}} YamlCfg
  */
 
 /**

--- a/index.js
+++ b/index.js
@@ -9,12 +9,13 @@ const fs = require('fs');
 const yaml = require('js-yaml');
 const { ensurePrsExist, readGHKey, checkGHKeyExists } = require('./github');
 const colors = require('colors');
-const { DEFAULT_REMOTE, MERGE_STEP_DELAY_MS, MERGE_STEP_DELAY_WAIT_FOR_LOCK } = require('./consts');
+const { DEFAULT_REMOTE, DEFAULT_MAIN_BRANCH, MERGE_STEP_DELAY_MS, MERGE_STEP_DELAY_WAIT_FOR_LOCK } = require('./consts');
 const path = require('path');
 // @ts-ignore
 const package = require('./package.json');
 const inquirer = require('inquirer');
 const shelljs = require('shelljs');
+const camelCase = require('lodash/camelCase');
 
 const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
 
@@ -63,8 +64,8 @@ async function pushBranches(sg, branches, forcePush, remote = DEFAULT_REMOTE) {
   console.log('All changes pushed ' + emoji.get('white_check_mark'));
 }
 
-async function getUnmergedBranches(sg, branches) {
-  const mergedBranchesOutput = await sg.raw(['branch', '--merged', 'master']);
+async function getUnmergedBranches(sg, branches, baseBranch = DEFAULT_MAIN_BRANCH) {
+  const mergedBranchesOutput = await sg.raw(['branch', '--merged', baseBranch]);
   const mergedBranches = mergedBranchesOutput
     .split('\n')
     .map(b => b.trim())
@@ -79,12 +80,14 @@ async function getConfigPath(sg) {
 
 /**
  * @typedef {string | Object.<string, { combined: boolean, initSha?: string }>} BranchCfg
+ * @typedef {{ mainBranch?: string, 'main-branch'?: string }} PrsCfg
  * @typedef {Object.<string, Array.<string | BranchCfg>>} TrainCfg
+ * @typedef {{ prs?: PrsCfg, trains: Array.<TrainCfg>}} YamlCfg
  */
 
 /**
  * @param {simpleGit.SimpleGit} sg
- * @return {Promise.<{trains: Array.<TrainCfg>}>}
+ * @return {Promise.<YamlCfg>}
  */
 async function loadConfig(sg) {
   const path = await getConfigPath(sg);
@@ -161,7 +164,56 @@ async function handleSwitchToBranchCommand(sg, sortedBranches, combinedBranch) {
   process.exit(0);
 }
 
+/**
+ * @param {YamlCfg} ymlConfig
+ * @param {string} path
+ */
+function getConfigOption(ymlConfig, path) {
+  const parts = path.split(/\./g);
+  let ptr = ymlConfig;
+  while (ptr && parts.length) {
+    const part = parts.shift();
+    // cater for both kebab case and camel cased variants of key, just for developer convenience.
+    ptr = part in ptr ? ptr[part] : ptr[camelCase(part)];
+  }
+  return ptr;
+}
+
 async function main() {
+  const sg = simpleGit();
+  if (!(await sg.checkIsRepo())) {
+    console.log('Not a git repo'.red);
+    process.exit(1);
+  }
+
+  // try to create or init the config first so we can read values from it
+  if (process.argv.includes('--init')) {
+    if (fs.existsSync(await getConfigPath(sg))) {
+      console.log('.pr-train.yml already exists');
+      process.exit(1);
+    }
+    const root = path.dirname(require.main.filename);
+    const cfgTpl = fs.readFileSync(`${root}/cfg_template.yml`);
+    fs.writeFileSync(await getConfigPath(sg), cfgTpl);
+    console.log(`Created a ".pr-train.yml" file. Please make sure it's gitignored.`);
+    process.exit(0);
+  }
+
+  let ymlConfig;
+  try {
+    ymlConfig = await loadConfig(sg);
+  } catch (e) {
+    if (e instanceof yaml.YAMLException) {
+      console.log('There seems to be an error in `.pr-train.yml`.');
+      console.log(e.message);
+      process.exit(1);
+    }
+    console.log('`.pr-train.yml` file not found. Please run `git pr-train --init` to create one.'.red);
+    process.exit(1);
+  }
+
+  const defaultBase = getConfigOption(ymlConfig, 'prs.main-branch-name') || DEFAULT_MAIN_BRANCH;
+
   program
     .version(package.version)
     .option('--init', 'Creates a .pr-train.yml file with an example configuration')
@@ -169,8 +221,9 @@ async function main() {
     .option('-l, --list', 'List branches in current train')
     .option('-r, --rebase', 'Rebase branches rather than merging them')
     .option('-f, --force', 'Force push to remote')
-    .option('--push-merged', 'Push all branches (inclusing those that have already been merged into master)')
+    .option('--push-merged', 'Push all branches (including those that have already been merged into the base branch)')
     .option('--remote <remote>', 'Set remote to push to. Defaults to "origin"')
+    .option('-b, --base <base>', `Specify the base branch to use for the first and combined PRs.`, defaultBase)
     .option('-c, --create-prs', 'Create GitHub PRs from your train branches');
 
   program.on('--help', () => {
@@ -199,37 +252,7 @@ async function main() {
 
   program.createPrs && checkGHKeyExists();
 
-  const sg = simpleGit();
-  if (!(await sg.checkIsRepo())) {
-    console.log('Not a git repo'.red);
-    process.exit(1);
-  }
-
-  if (program.init) {
-    if (fs.existsSync(await getConfigPath(sg))) {
-      console.log('.pr-train.yml already exists');
-      process.exit(1);
-    }
-    const root = path.dirname(require.main.filename);
-    const cfgTpl = fs.readFileSync(`${root}/cfg_template.yml`);
-    fs.writeFileSync(await getConfigPath(sg), cfgTpl);
-    console.log(`Created a ".pr-train.yml" file. Please make sure it's gitignored.`);
-    process.exit(0);
-  }
-
-  let ymlConfig;
-  try {
-    ymlConfig = await loadConfig(sg);
-  } catch (e) {
-    if (e instanceof yaml.YAMLException) {
-      console.log('There seems to be an error in `.pr-train.yml`.');
-      console.log(e.message);
-      process.exit(1);
-    }
-    console.log('`.pr-train.yml` file not found. Please run `git pr-train --init` to create one.'.red);
-    process.exit(1);
-  }
-
+  const baseBranch = program.base; // will have default value if one is not supplied
   const { current: currentBranch, all: allBranches } = await sg.branchLocal();
   const trainCfg = await getBranchesConfigInCurrentTrain(sg, ymlConfig);
   if (!trainCfg) {
@@ -273,7 +296,7 @@ async function main() {
   async function findAndPushBranches() {
     let branchesToPush = sortedTrainBranches;
     if (!program.pushMerged) {
-      branchesToPush = await getUnmergedBranches(sg, sortedTrainBranches);
+      branchesToPush = await getUnmergedBranches(sg, sortedTrainBranches, baseBranch);
       const branchDiff = difference(sortedTrainBranches, branchesToPush);
       if (branchDiff.length > 0) {
         console.log(`Not pushing already merged branches: ${branchDiff.join(', ')}`);
@@ -286,7 +309,13 @@ async function main() {
   // the PR titles and descriptions). Just push and create the PRs.
   if (program.createPrs) {
     await findAndPushBranches();
-    await ensurePrsExist(sg, sortedTrainBranches, combinedTrainBranch, program.remote);
+    await ensurePrsExist({
+      sg,
+      allBranches: sortedTrainBranches,
+      combinedBranch: combinedTrainBranch,
+      remote: program.remote,
+      baseBranch,
+    });
     return;
   }
 
@@ -309,6 +338,6 @@ async function main() {
 }
 
 main().catch(e => {
-  console.log(`${emoji.get('x')}  An error occured. Was there a conflict perhaps?`.red);
+  console.log(`${emoji.get('x')}  An error occurred. Was there a conflict perhaps?`.red);
   console.error('error', e);
 });


### PR DESCRIPTION
<pr-train-toc>

|     | PR | Description                                          |
| --- | -- | ---------------------------------------------------- |
|  👉 | #30 | Added ability to customise the base branch          |
|     | greglockwood#3 | Draft PR support                                     |
|     | greglockwood#4 | Cater for body being nullish or empty                |
|     | greglockwood#5 | Putting the table back in 'table of contents'!       |
|     | greglockwood#6 | Added support to print links to PRs in terminal      |
|     | greglockwood#7 | Work when remote URL doesn't have .git suffix        |
|     | #31 | **[combined branch]**                               |

</pr-train-toc>

## Which problem does this PR solve?

There are a few scenarios not covered by the current functionality.

1. Create a chain of PRs off a branch that is not `master`, meaning the base should be set to the "parent" branch of the first branch in the chain, not `master`.
2. [GitHub is encouraging everyone](https://github.com/github/renaming) to rename their main branch to something other than the slavery-inspired `master`. New repos default to using `main` instead.

## Main changes

### 1. Add `--base` to allow customizing the base branch

The first part was adding a new command line flag and propagating it through the functions to allow specifying a custom base branch to use other than `master`.

### 2. Adding a configuration option to specify a default base branch

This is the first PR in a chain because I started a new convention where configuration options about the behavior can be specified in an optional `prs` section in the `.pr-train.yml` config file. By chaining the remaining PRs off this one, I can re-use the helper method for getting the config value.

Most of the PRs in the chain add a configuration option to this section, and this one is no different. This one adds a `main-base-branch` setting to allow customizing the main branch for the repository you are working on, which fixes issue #24 and may help with #18 and #10.

Specifying this `main-base-branch` option sets the base branch to use when one is not specified explicitly with the `--base` command-line option mentioned above.

## Suggested CR ordering of files?

1. `consts.js` and `cfg_template.yml`, the "easy" ones.
2. `README.md` for the addition to the docs.
3. `index.js`
4. `github.js`

## How I tested it works

I have tested the following scenarios:

1. No `main-base-branch` setting, no `--base` specified via command-line. First and combined PRs use `master` as the base, which matches the current behavior.
2. Setting `main-base-branch: main`, no `--base` specified via command-line. First and combined PRs use `main` as the base, which is correct.
3. Setting `main-base-branch: main` and `--base master` specified via command-line. First and combined PRs use `master` as the base, which is correct.
4. No `main-base-branch` setting, `--base main` specified via command-line. First and combined PRs use `main` as the base, which is correct.
