### PR TITLE
Handle empty trains

### DIFF
--- a/index.js
+++ b/index.js
@@ -116,7 +116,7 @@ async function getBranchesConfigInCurrentTrain(sg, config) {
     return null;
   }
   const key = Object.keys(trains).find(trainKey => {
-    const branches = trains[trainKey];
+    const branches = trains[trainKey] ?? [];
     const branchNames = branches.map(b => getBranchName(b));
     return branchNames.indexOf(currentBranch) >= 0;
   });


### PR DESCRIPTION
Nit: Fix null ref exception if there is an empty train in `.pr-train.yml`. I stumbled into this while shuffling branches between PR trains.