### PR TITLE
Replace HTML tables with ordered list to take profit of the nice GH PR rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,3 +155,14 @@ e.g. `git pr-train -p -c -b feat/my-feature-base`
 
 To have the command output include a link to the PR that was created or updated,
 simply add `print-urls: true` to the `prs` section of the config file.
+
+
+## Contributing
+
+You can check out this repo, perform changes and install the module globally by running:
+
+```
+npm install  -g
+```
+
+Then follow the instructions under [Usage](#Usage) in order to test.

--- a/github.js
+++ b/github.js
@@ -39,12 +39,12 @@ function constructTrainNavigation(branchToPrDict, currentBranch, combinedBranch)
     const maybeHandRight = branch === currentBranch ? ' 👈' : ' ';
     const combinedInfo = branch === combinedBranch ? ' **[combined branch]** ' : ' ';
     const prNumber = `#${branchToPrDict[branch].pr}`;
-    const prInfoHtml = `<li>${combinedInfo}${prNumber}${maybeHandRight}</li>`
+    const prInfoHtml = `1. ${prNumber}${combinedInfo}${maybeHandRight}`
     prList.push(prInfoHtml);
   });
   if (prList.length > 0) {
     contents += '### 🚂 PR Train \n';
-    contents += '<ol>' + prList.join('') +'</ol>\n';
+    contents += prList.join('\n');
   }
   contents += '\n</pr-train-toc>'
   return contents;

--- a/github.js
+++ b/github.js
@@ -42,10 +42,8 @@ function constructTrainNavigation(branchToPrDict, currentBranch, combinedBranch)
     const prInfoHtml = `1. ${prNumber}${combinedInfo}${maybeHandRight}`
     prList.push(prInfoHtml);
   });
-  if (prList.length > 0) {
-    contents += '### 🚂 PR Train \n';
-    contents += prList.join('\n');
-  }
+  contents += '### 🚂 PR Train \n';
+  contents += prList.join('\n');
   contents += '\n</pr-train-toc>'
   return contents;
 }

--- a/github.js
+++ b/github.js
@@ -42,7 +42,8 @@ function constructTrainNavigation(branchToPrDict, currentBranch, combinedBranch)
     const prTitle = branchToPrDict[branch].title.trim();
     const prNumber = `#${branchToPrDict[branch].pr}`;
     const prInfo = `${combinedInfo}${prTitle}`.trim();
-    tableData.push([maybeHandRight, prNumber, prInfo]);
+    const prInfoHtml = `<ul><li>${prInfo}</li></ul>`
+    tableData.push([maybeHandRight, prNumber, prInfoHtml]);
   });
   contents += table(tableData, { stringLength: width }) + '\n';
   contents += '\n</pr-train-toc>'

--- a/github.js
+++ b/github.js
@@ -9,7 +9,6 @@ const fs = require('fs');
 const get = require('lodash/get');
 const colors = require('colors');
 const emoji = require('node-emoji');
-const table = require('markdown-table');
 const width = require('string-width');
 
 /**
@@ -35,15 +34,18 @@ async function constructPrMsg(sg, branch) {
  */
 function constructTrainNavigation(branchToPrDict, currentBranch, combinedBranch) {
   let contents = '<pr-train-toc>\n\n';
-  let tableData = [['', 'PR', 'Description']];
+  let prList = [];
   Object.keys(branchToPrDict).forEach((branch) => {
-    const maybeHandRight = branch === currentBranch ? '👉 ' : ' ';
+    const maybeHandRight = branch === currentBranch ? ' 👈' : ' ';
     const combinedInfo = branch === combinedBranch ? ' **[combined branch]** ' : ' ';
     const prNumber = `#${branchToPrDict[branch].pr}`;
-    const prInfoHtml = `<ul><li>${combinedInfo}${prNumber}</li></ul>`
-    tableData.push([maybeHandRight, prNumber, prInfoHtml]);
+    const prInfoHtml = `<li>${combinedInfo}${prNumber}${maybeHandRight}</li>`
+    prList.push(prInfoHtml);
   });
-  contents += table(tableData, { stringLength: width }) + '\n';
+  if (prList.length > 0) {
+    contents += '### 🚂 PR Train \n';
+    contents += '<ol>' + prList.join('') +'</ol>\n';
+  }
   contents += '\n</pr-train-toc>'
   return contents;
 }

--- a/github.js
+++ b/github.js
@@ -39,7 +39,7 @@ function constructTrainNavigation(branchToPrDict, currentBranch, combinedBranch)
     const maybeHandRight = branch === currentBranch ? ' 👈' : ' ';
     const combinedInfo = branch === combinedBranch ? ' **[combined branch]** ' : ' ';
     const prNumber = `#${branchToPrDict[branch].pr}`;
-    const prInfoHtml = `1. ${prNumber}${combinedInfo}${maybeHandRight}`
+    const prInfoHtml = `1. ${prNumber}${combinedInfo}${maybeHandRight}`;
     prList.push(prInfoHtml);
   });
   contents += '### 🚂 PR Train \n';

--- a/github.js
+++ b/github.js
@@ -39,10 +39,8 @@ function constructTrainNavigation(branchToPrDict, currentBranch, combinedBranch)
   Object.keys(branchToPrDict).forEach((branch) => {
     const maybeHandRight = branch === currentBranch ? '👉 ' : ' ';
     const combinedInfo = branch === combinedBranch ? ' **[combined branch]** ' : ' ';
-    const prTitle = branchToPrDict[branch].title.trim();
     const prNumber = `#${branchToPrDict[branch].pr}`;
-    const prInfo = `${combinedInfo}${prTitle}`.trim();
-    const prInfoHtml = `<ul><li>${prInfo}</li></ul>`
+    const prInfoHtml = `<ul><li>${combinedInfo}${prNumber}</li></ul>`
     tableData.push([maybeHandRight, prNumber, prInfoHtml]);
   });
   contents += table(tableData, { stringLength: width }) + '\n';

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "lodash": "^4.17.15",
     "lodash.difference": "^4.5.0",
     "lodash.sortby": "^4.7.0",
-    "markdown-table": "^2.0.0",
     "node-emoji": "^1.8.1",
     "octonode": "^0.9.3",
     "progress": "^2.0.0",


### PR DESCRIPTION
When using bullet points for Github PR Urls, github enhances the experience by fetching the PR title/number and it also shows the status of the PR.

It would be nice to support this as part of rendering the table.

🚂 Test Chain created with these changes: https://github.com/Canva/canva/pull/398034
