### PR TITLE
Add instructions for fine-grained access tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,13 @@ Now whenever you have a chain of branches, list them in `.pr-train.yml` to tell 
 
 ### Automatically create GitHub PRs from chained branches
 
-**Pre-requisite**: Create a `${HOME}/.pr-train` file with a single line which is your GitHub personal access token (you can create one [here](https://github.com/settings/personal-access-tokens)). The token must have access to the repository you're pushing your train to, and have the permissions `Contents: Read-only` and `Pull requests: Read and write`.
+#### Setup
+
+Create a GitHub personal access token in [GitHub Settings > Personal access tokens > Fine-grained tokens](https://github.com/settings/personal-access-tokens). Allow access to repositories you wish to push PR trains to, and set the permissions to `Contents: Read-only` and `Pull requests: Read and write`. Once generated, create a `${HOME}/.pr-train` file containing the generated token and nothing else.
+
+"Classic" GitHub tokens can be used instead of fine-grained tokens by providing the `repo` scope.
+
+#### Usage
 
 Run `git pr-train -p --create-prs` to create GitHub PRs with a "content table" section. PR titles are taken from the commit message titles of each branch HEAD. You'll be prompted before the PRs are created.
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Now whenever you have a chain of branches, list them in `.pr-train.yml` to tell 
 
 ### Automatically create GitHub PRs from chained branches
 
-**Pre-requisite**: Create a `${HOME}/.pr-train` file with a single line which is your GH personal access token (you can create one [here](https://github.com/settings/tokens)). The `repo` scope, with ` Full control of private repositories` is needed.
+**Pre-requisite**: Create a `${HOME}/.pr-train` file with a single line which is your GitHub personal access token (you can create one [here](https://github.com/settings/personal-access-tokens)). The token must have access to the repository you're pushing your train to, and have the permissions `Contents: Read-only` and `Pull requests: Read and write`.
 
 Run `git pr-train -p --create-prs` to create GitHub PRs with a "content table" section. PR titles are taken from the commit message titles of each branch HEAD. You'll be prompted before the PRs are created.
 


### PR DESCRIPTION
`pr-train` appears to work out of the box with fine-grained tokens. This PR updates the README with instructions on creating a fine-grained token with the correct permissions, for users who prefer or are required to use them.